### PR TITLE
Add compact str example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
 ### Added
 
 - `from_infallible!()` utility macro added for providing universal `From<Infallible>` impls
+- Added an example using `CompactString` from the `compact_str` crate ([#15])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.2.3] - 2022-06-15
+## [Unreleased]
+
+### Added
+
+- `from_infallible!()` utility macro added for providing universal `From<Infallible>` impls
+- Added an example using `CompactString` from the `compact_str` crate ([#15])
+
 ### Changed
+
+- `Validator::Error` is now expected to implement `From<Infallible>` to allow potentially
+  fallible wrapped type conversions
+
+[#15]: https://github.com/neoeinstein/aliri_braid/pull/15
+
+## [0.2.3] - 2022-06-15
+
+### Changed
+
 - Added allow for clippy lint on automatically derived `serde::Deserialize` impls
+
+<!--markdownlint-disable-file MD024 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
 ### Added
 
 - `from_infallible!()` utility macro added for providing universal `From<Infallible>` impls
-- Added an example using `CompactString` from the `compact_str` crate ([#15])
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
 
 # Generate README
 # cargo readme -r aliri_braid/ -o ../README.md --no-license
+
+[patch.crates-io]
+compact_str = { git = "https://github.com/ParkMyCar/compact_str", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
 
 # Generate README
 # cargo readme -r aliri_braid/ -o ../README.md --no-license
+
+[patch.crates-io]
+compact_str = { git = "https://github.com/neoeinstein/compact_str", branch = "impl-into-string" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 # cargo readme -r aliri_braid/ -o ../README.md --no-license
 
 [patch.crates-io]
-compact_str = { git = "https://github.com/neoeinstein/compact_str", branch = "impl-into-string" }
+compact_str = { git = "https://github.com/ParkMyCar/compact_str", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
 
 # Generate README
 # cargo readme -r aliri_braid/ -o ../README.md --no-license
-
-[patch.crates-io]
-compact_str = { git = "https://github.com/ParkMyCar/compact_str", branch = "main" }

--- a/aliri_braid/Cargo.toml
+++ b/aliri_braid/Cargo.toml
@@ -22,6 +22,7 @@ aliri_braid_impl = { version = "=0.2.3", path = "../aliri_braid_impl" }
 [dev-dependencies]
 bytes = "1"
 bytestring = "1.1"
+compact_str = "0.5"
 quickcheck = "1"
 quickcheck_macros = "1.0.0"
 serde = { version = "1", features = [ "derive" ] }

--- a/aliri_braid/src/lib.rs
+++ b/aliri_braid/src/lib.rs
@@ -917,6 +917,9 @@ pub trait Normalizer: Validator {
 macro_rules! from_infallible {
     ($ty:ty) => {
         impl ::core::convert::From<::core::convert::Infallible> for $ty {
+            // This should always be trivially inlineable as it allows
+            // the compiler to eliminate code paths from this unreachable path.
+            #[inline(always)]
             fn from(x: ::core::convert::Infallible) -> Self {
                 match x {}
             }

--- a/aliri_braid/src/lib.rs
+++ b/aliri_braid/src/lib.rs
@@ -744,16 +744,22 @@
 //!
 //! The `braid` macro can be used to define a custom string type that wraps types
 //! other than the standard `String`. This allows defining a braid that is backed
-//! by a type that offers small-string optimizations, such as [`SmartString`].
+//! by a type that offers small-string optimizations, such as [`SmartString`] or
+//! [`CompactString`].
 //!
 //! Functions that expose the inner wrapped type can be made private by adding the
 //! `no_expose` parameter to avoid leaking the type in the public interface.
 //!
 //! [`SmartString`]: https://docs.rs/smartstring/*/smartstring/struct.SmartString.html
+//! [`CompactString`]: https://docs.rs/compact_str/*/compact_str/struct.CompactString.html
 //!
 //! ```
 //! # use aliri_braid::braid;
+//! use compact_str::CompactString;
 //! use smartstring::{SmartString, LazyCompact};
+//!
+//! #[braid(no_expose)]
+//! pub struct UserId(CompactString);
 //!
 //! #[braid(no_expose)]
 //! pub struct AltUserId(SmartString<LazyCompact>);

--- a/aliri_braid/src/lib.rs
+++ b/aliri_braid/src/lib.rs
@@ -744,22 +744,16 @@
 //!
 //! The `braid` macro can be used to define a custom string type that wraps types
 //! other than the standard `String`. This allows defining a braid that is backed
-//! by a type that offers small-string optimizations, such as [`SmartString`] or
-//! [`CompactString`].
+//! by a type that offers small-string optimizations, such as [`SmartString`].
 //!
 //! Functions that expose the inner wrapped type can be made private by adding the
 //! `no_expose` parameter to avoid leaking the type in the public interface.
 //!
 //! [`SmartString`]: https://docs.rs/smartstring/*/smartstring/struct.SmartString.html
-//! [`CompactString`]: https://docs.rs/compact_str/*/compact_str/struct.CompactString.html
 //!
 //! ```
 //! # use aliri_braid::braid;
-//! use compact_str::CompactString;
 //! use smartstring::{SmartString, LazyCompact};
-//!
-//! #[braid(no_expose)]
-//! pub struct UserId(CompactString);
 //!
 //! #[braid(no_expose)]
 //! pub struct AltUserId(SmartString<LazyCompact>);

--- a/aliri_braid/tests/jumble.rs
+++ b/aliri_braid/tests/jumble.rs
@@ -1,6 +1,6 @@
 #![deny(unsafe_code)]
 
-use std::{borrow::Cow, fmt};
+use std::{borrow::Cow, convert::Infallible, fmt};
 
 use aliri_braid::braid;
 
@@ -47,6 +47,14 @@ impl std::fmt::Display for InvalidData {
         f.write_str("found 4-byte UTF-8 codepoints")
     }
 }
+
+impl From<Infallible> for InvalidData {
+    #[inline(always)]
+    fn from(x: Infallible) -> Self {
+        match x {}
+    }
+}
+
 impl std::error::Error for InvalidData {}
 
 impl aliri_braid::Validator for ValidatedBuf {

--- a/aliri_braid/tests/normalized.rs
+++ b/aliri_braid/tests/normalized.rs
@@ -1,5 +1,6 @@
 use aliri_braid::braid;
 use std::borrow::Cow;
+use std::convert::Infallible;
 use std::{error, fmt};
 
 #[derive(Debug)]
@@ -17,7 +18,15 @@ impl fmt::Display for InvalidString {
     }
 }
 
+impl From<Infallible> for InvalidString {
+    #[inline(always)]
+    fn from(x: Infallible) -> Self {
+        match x {}
+    }
+}
+
 impl error::Error for InvalidString {}
+
 /// A non-empty [`String`] normalized to lowercase
 #[braid(
     serde,

--- a/aliri_braid/tests/too_many_braids.rs
+++ b/aliri_braid/tests/too_many_braids.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::convert::Infallible;
 use std::{error, fmt};
 #[derive(Debug)]
 pub enum InvalidString {
@@ -12,6 +13,13 @@ impl fmt::Display for InvalidString {
             Self::EmptyString => f.write_str("string cannot be empty"),
             Self::InvalidCharacter => f.write_str("string contains invalid uppercase character"),
         }
+    }
+}
+
+impl From<Infallible> for InvalidString {
+    #[inline(always)]
+    fn from(x: Infallible) -> Self {
+        match x {}
     }
 }
 
@@ -60,6 +68,13 @@ impl fmt::Display for InvalidScopeToken {
                 position, value
             )),
         }
+    }
+}
+
+impl From<Infallible> for InvalidScopeToken {
+    #[inline(always)]
+    fn from(x: Infallible) -> Self {
+        match x {}
     }
 }
 

--- a/aliri_braid/tests/validated.rs
+++ b/aliri_braid/tests/validated.rs
@@ -1,5 +1,5 @@
 use aliri_braid::braid;
-use std::{error, fmt};
+use std::{convert::Infallible, error, fmt};
 
 #[derive(Debug)]
 pub enum InvalidScopeToken {
@@ -16,6 +16,13 @@ impl fmt::Display for InvalidScopeToken {
                 position, value
             )),
         }
+    }
+}
+
+impl From<Infallible> for InvalidScopeToken {
+    #[inline(always)]
+    fn from(x: Infallible) -> Self {
+        match x {}
     }
 }
 

--- a/aliri_braid_examples/Cargo.toml
+++ b/aliri_braid_examples/Cargo.toml
@@ -18,4 +18,4 @@ bytes = "1"
 bytestring = { version = "1.1", features = [ "serde" ] }
 serde = { version = "1", features = [ "derive" ] }
 smartstring = { version = "1", features = [ "serde" ] }
-compact_str = { version = "0.4", features = [ "serde" ] }
+compact_str = { version = "0.5", features = [ "serde" ] }

--- a/aliri_braid_examples/src/minimal.rs
+++ b/aliri_braid_examples/src/minimal.rs
@@ -15,6 +15,12 @@ pub struct MinimalUsernameBuf(MinimalString);
 )]
 pub struct MinimalString(String);
 
+impl From<String> for MinimalString {
+    fn from(s: String) -> Self {
+        MinimalString(s)
+    }
+}
+
 impl From<&'_ str> for MinimalString {
     fn from(s: &str) -> Self {
         MinimalString(s.into())

--- a/aliri_braid_examples/src/normalized.rs
+++ b/aliri_braid_examples/src/normalized.rs
@@ -14,6 +14,7 @@
 
 use aliri_braid::braid;
 use std::borrow::Cow;
+use std::convert::Infallible;
 use std::{error, fmt};
 
 /// An error indicating that the provided value was invalid
@@ -29,6 +30,13 @@ impl fmt::Display for InvalidString {
             Self::EmptyString => f.write_str("string cannot be empty"),
             Self::InvalidCharacter => f.write_str("string contains invalid uppercase character"),
         }
+    }
+}
+
+impl From<Infallible> for InvalidString {
+    #[inline(always)]
+    fn from(x: Infallible) -> Self {
+        match x {}
     }
 }
 

--- a/aliri_braid_examples/src/sso_wrapper.rs
+++ b/aliri_braid_examples/src/sso_wrapper.rs
@@ -18,3 +18,11 @@ use smartstring::alias::String;
 /// implicitly use the `String` type in the namespace where it is defined.
 #[braid(serde, ref_doc = "A borrowed reference to a string slice wrapper")]
 pub struct SmartUsernameBuf;
+
+/// An example of a wrapper with small-string optimization
+///
+/// This type wraps the around a [`compact_str::CompactString`], but that
+/// implementation detail won't be exposed through the type API due to
+/// the use of the `no_expose` braid parameter.
+#[braid(serde, no_expose)]
+pub struct CompactData(compact_str::CompactString);

--- a/aliri_braid_examples/src/sso_wrapper.rs
+++ b/aliri_braid_examples/src/sso_wrapper.rs
@@ -19,18 +19,10 @@ use smartstring::alias::String;
 #[braid(serde, ref_doc = "A borrowed reference to a string slice wrapper")]
 pub struct SmartUsernameBuf;
 
-// This doesn't work right now as `CompactString` doesn't implement `Into<String>`.
-//
-// /// An example of a wrapper around a [`compact_str::CompactString`] with
-// /// small-string optimization
-// ///
-// /// This type ends in _Buf_, so the borrowed form of this type
-// /// will be named [`CompactUsername`].
-// ///
-// /// Because the no type is explicitly named here, the inner field will
-// /// implicitly use the `String` type in the namespace where it is defined.
-// #[braid(
-//     serde,
-//     ref_doc = "A borrowed reference to a string slice wrapper"
-// )]
-// pub struct CompactUsernameBuf(compact_str::CompactString);
+/// An example of a wrapper with small-string optimization
+///
+/// This type wraps the around a [`compact_str::CompactString`], but that
+/// implementation detail won't be exposed through the type API due to
+/// the use of the `no_expose` braid parameter.
+#[braid(serde, no_expose)]
+pub struct CompactData(compact_str::CompactString);

--- a/aliri_braid_examples/src/sso_wrapper.rs
+++ b/aliri_braid_examples/src/sso_wrapper.rs
@@ -18,11 +18,3 @@ use smartstring::alias::String;
 /// implicitly use the `String` type in the namespace where it is defined.
 #[braid(serde, ref_doc = "A borrowed reference to a string slice wrapper")]
 pub struct SmartUsernameBuf;
-
-/// An example of a wrapper with small-string optimization
-///
-/// This type wraps the around a [`compact_str::CompactString`], but that
-/// implementation detail won't be exposed through the type API due to
-/// the use of the `no_expose` braid parameter.
-#[braid(serde, no_expose)]
-pub struct CompactData(compact_str::CompactString);

--- a/aliri_braid_examples/src/validated.rs
+++ b/aliri_braid_examples/src/validated.rs
@@ -10,7 +10,7 @@
 //! a valid value for the type.
 
 use aliri_braid::braid;
-use std::{error, fmt};
+use std::{convert::Infallible, error, fmt};
 
 /// An error indicating that the provided string is not a valid scope token
 #[derive(Debug)]
@@ -30,6 +30,13 @@ impl fmt::Display for InvalidScopeToken {
                 position, value
             )),
         }
+    }
+}
+
+impl From<Infallible> for InvalidScopeToken {
+    #[inline(always)]
+    fn from(x: Infallible) -> Self {
+        match x {}
     }
 }
 

--- a/aliri_braid_impl/src/codegen/mod.rs
+++ b/aliri_braid_impl/src/codegen/mod.rs
@@ -56,6 +56,7 @@ pub struct Params<'a> {
     owned_attrs: AttrList<'a>,
     std_lib: StdLib,
     check_mode: IndefiniteCheckMode,
+    expose_inner: bool,
     impls: Impls,
 }
 
@@ -68,6 +69,7 @@ impl<'a> Default for Params<'a> {
             owned_attrs: AttrList::new(),
             std_lib: StdLib::default(),
             check_mode: IndefiniteCheckMode::None,
+            expose_inner: true,
             impls: Impls::default(),
         }
     }
@@ -155,6 +157,9 @@ impl<'a> Params<'a> {
                 syn::NestedMeta::Meta(syn::Meta::Path(p)) if p == symbol::NO_STD => {
                     params.std_lib = StdLib::no_std(p.span());
                 }
+                syn::NestedMeta::Meta(syn::Meta::Path(p)) if p == symbol::NO_EXPOSE => {
+                    params.expose_inner = false;
+                }
                 syn::NestedMeta::Meta(
                     syn::Meta::Path(ref path)
                     | syn::Meta::NameValue(syn::MetaNameValue { ref path, .. }),
@@ -184,6 +189,7 @@ impl<'a> Params<'a> {
             owned_attrs,
             std_lib,
             check_mode,
+            expose_inner,
             impls,
         } = self;
 
@@ -210,6 +216,7 @@ impl<'a> Params<'a> {
             ref_ty,
 
             std_lib,
+            expose_inner,
             impls,
         })
     }
@@ -352,6 +359,7 @@ pub struct CodeGen<'a> {
     ref_ty: syn::Type,
 
     std_lib: StdLib,
+    expose_inner: bool,
     impls: Impls,
 }
 
@@ -376,6 +384,7 @@ impl<'a> CodeGen<'a> {
             ty: &self.body.ident,
             ref_ty: &self.ref_ty,
             std_lib: &self.std_lib,
+            expose_inner: self.expose_inner,
             impls: &self.impls,
         }
     }

--- a/aliri_braid_impl/src/codegen/symbol.rs
+++ b/aliri_braid_impl/src/codegen/symbol.rs
@@ -16,6 +16,7 @@ pub const REF_DOC: Symbol = Symbol("ref_doc");
 pub const REF_ATTR: Symbol = Symbol("ref_attr");
 pub const OWNED_ATTR: Symbol = Symbol("owned_attr");
 pub const NO_STD: Symbol = Symbol("no_std");
+pub const NO_EXPOSE: Symbol = Symbol("no_expose");
 pub const VALIDATOR: Symbol = Symbol(super::check_mode::VALIDATOR);
 pub const NORMALIZER: Symbol = Symbol(super::check_mode::NORMALIZER);
 

--- a/aliri_braid_impl/src/lib.rs
+++ b/aliri_braid_impl/src/lib.rs
@@ -62,6 +62,8 @@ use syn::parse_macro_input;
 ///     If `omit`, then no implementations will be provided.
 /// * `serde = "impl|omit"` (default `omit`)
 ///   * Adds serialize and deserialize implementations
+/// * `no_expose`
+///   * Functions that expose the internal field type will not be exposed publicly.
 /// * `no_std`
 ///   * Generates `no_std`-compatible braid (still requires `alloc`)
 #[proc_macro_attribute]


### PR DESCRIPTION
This is currently blocked on a publishing the remaining needed trait implementation in the `compact_str` crate. Once that has been released, we can remove the `[patch.crates-io]`, update the version, and merge.